### PR TITLE
Multiple clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,30 @@ git clone git@github.com:rianp/echo-server.git
 cd echo-server
 ```
 
-<<<<<<< Updated upstream
-3. Install IntelliJ and JDK (Java Development Kit) if you haven't already. You can download IntelliJ from the official website and JDK from the Oracle website. Make sure to follow the installation instructions for your specific operating system.
+## Run In IntelliJ IDE 
 
-4. Open the project in IntelliJ:
+1. Install IntelliJ and JDK (Java Development Kit) if you haven't already. You can download IntelliJ from the official website and JDK from the Oracle website. Make sure to follow the installation instructions for your specific operating system.
+
+2. Open the project in IntelliJ:
 - Launch IntelliJ.
 - Click on "Open" or "Import Project."
 - Browse to the cloned echo-server directory and select it.
 - IntelliJ will detect the project configuration and set it up.
+- Open two terminal windows and follow the instructions below.
 
-5. Build the project using Gradle:
+## Run Using The Terminal
+
+1. In the root directory (`echo-server`), run the server:
 ```bash
-gradle build
+gradle bootServer
 ```
 
-6. Run the server:
+2. Then in a separate terminal window, run the client:
 ```bash
-=======
-3. Build the project using Gradle:
-```
-gradle build
+ gradle --console plain bootClient
 ```
 
-1. Run the server:
-```
->>>>>>> Stashed changes
-gradle run
-```
-
-**The server should now be running on localhost at port (todo: port number).**
+**The server should now be running on localhost at port 49151.**
 
 ## Testing
 **This project includes JUnit tests to ensure that the server is functioning correctly.**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,9 @@
+import java.io.InputStream
+
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     application
-    id("com.adarshr.test-logger") version "3.2.0"
+//    id("com.adarshr.test-logger") version "3.2.0"
 }
 
 repositories {
@@ -26,14 +28,15 @@ tasks.named<Test>("test") {
     useJUnitPlatform()
 }
 
-tasks.register("bootServer", JavaExec::class.java) {
+tasks.create<JavaExec>("bootServer") {
     mainClass.set("echo.server.ServerRunner")
     classpath = sourceSets["main"].runtimeClasspath
 }
 
-tasks.register("bootClient", JavaExec::class.java) {
+tasks.create<JavaExec>("bootClient") {
     mainClass.set("echo.client.ClientRunner")
     classpath = sourceSets["main"].runtimeClasspath
+    standardInput = System.`in`
 }
 
 //tasks.named("bootServer") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,3 @@ tasks.create<JavaExec>("bootClient") {
     classpath = sourceSets["main"].runtimeClasspath
     standardInput = System.`in`
 }
-
-//tasks.named("bootServer") {
-//    finalizedBy("bootClient")
-//}

--- a/app/src/main/java/echo/Console.java
+++ b/app/src/main/java/echo/Console.java
@@ -11,8 +11,8 @@ public class Console {
   }
 
   public String inputString(String prompt) throws IOException {
-    BufferedReader userInput = new BufferedReader(new InputStreamReader(System.in));
     print(prompt);
+    BufferedReader userInput = new BufferedReader(new InputStreamReader(System.in));
     return userInput.readLine();
   }
 }

--- a/app/src/main/java/echo/SocketIO.java
+++ b/app/src/main/java/echo/SocketIO.java
@@ -8,8 +8,8 @@ public class SocketIO {
   public String readMessage(Socket serverConnection) {
     String message = "";
     try {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(serverConnection.getInputStream()));
-      message = reader.readLine();
+      BufferedReader in = new BufferedReader(new InputStreamReader(serverConnection.getInputStream()));
+      message = in.readLine();
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/app/src/main/java/echo/client/EchoClient.java
+++ b/app/src/main/java/echo/client/EchoClient.java
@@ -23,6 +23,7 @@ public class EchoClient {
       if ("quit".equals(message)) {
         break;
       }
+//      console.print(message);
       socketIO.sendMessage(socket, message);
       String echo = socketIO.readMessage(socket);
       console.print(echo);

--- a/app/src/main/java/echo/server/EchoServer.java
+++ b/app/src/main/java/echo/server/EchoServer.java
@@ -7,35 +7,37 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import echo.Console;
 
-public class EchoServer {
-
+public class EchoServer implements Runnable {
   private final Console console;
   private final SocketIO socketIO;
-  private final ServerSocket serverSocket;
-  private Socket serverConnection;
+  private final Socket clientSocket;
 
-  public EchoServer(Console console, ServerSocket serverSocket, SocketIO socketIO) {
+  public EchoServer(Console console, SocketIO socketIO, Socket clientSocket) {
     this.console = console;
     this.socketIO = socketIO;
-    this.serverSocket = serverSocket;
+    this.clientSocket = clientSocket;
   }
 
-  public void start() throws IOException {
+  @Override
+  public void run() {
     String message;
-    serverConnection = this.acceptClientConnectionRequest();
-    console.print("Connection established!");
-    while ((message = socketIO.readMessage(serverConnection)) != null) {
-      socketIO.sendMessage(serverConnection, message);
+    while ((message = socketIO.readMessage(clientSocket)) != null) {
+      try {
+        socketIO.sendMessage(clientSocket, message);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 
-  public Socket acceptClientConnectionRequest() {
-    Socket clientSocket;
-    try {
-      clientSocket = this.serverSocket.accept();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    return clientSocket;
-  }
+
+//  public Socket acceptClientConnectionRequest() {
+//    Socket clientSocket;
+//    try {
+//      clientSocket = this.serverSocket.accept();
+//    } catch (IOException e) {
+//      throw new RuntimeException(e);
+//    }
+//    return clientSocket;
+//  }
 }

--- a/app/src/main/java/echo/server/EchoServer.java
+++ b/app/src/main/java/echo/server/EchoServer.java
@@ -22,7 +22,7 @@ public class EchoServer {
 
   public void start() throws IOException {
     String message;
-    Socket serverConnection = this.acceptClientConnectionRequest();
+    serverConnection = this.acceptClientConnectionRequest();
     console.print("Connection established!");
     while ((message = socketIO.readMessage(serverConnection)) != null) {
       socketIO.sendMessage(serverConnection, message);

--- a/app/src/main/java/echo/server/EchoServer.java
+++ b/app/src/main/java/echo/server/EchoServer.java
@@ -20,24 +20,19 @@ public class EchoServer implements Runnable {
 
   @Override
   public void run() {
-    String message;
-    while ((message = socketIO.readMessage(clientSocket)) != null) {
-      try {
+    try {
+      String message;
+      while ((message = socketIO.readMessage(clientSocket)) != null) {
         socketIO.sendMessage(clientSocket, message);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      try {
+        clientSocket.close();
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        e.printStackTrace();
       }
     }
   }
-
-
-//  public Socket acceptClientConnectionRequest() {
-//    Socket clientSocket;
-//    try {
-//      clientSocket = this.serverSocket.accept();
-//    } catch (IOException e) {
-//      throw new RuntimeException(e);
-//    }
-//    return clientSocket;
-//  }
 }

--- a/app/src/main/java/echo/server/ServerRunner.java
+++ b/app/src/main/java/echo/server/ServerRunner.java
@@ -13,16 +13,23 @@ public class ServerRunner {
     Console console = new Console();
     SocketIO socketIO = new SocketIO();
 
-    console.print("Welcome to the Echo Server!\nStarting Server...");
-    ServerSocket serverSocket = new ServerSocket(49151);
-    console.print("Echo Server started and waiting for clients... ");
+    ServerSocket serverSocket = null;
+    try {
+      console.print("Welcome to the Echo Server!\nStarting Server...");
+      serverSocket = new ServerSocket(49151);
+      console.print("Echo Server started and waiting for clients... ");
 
-    while (true) {
-      Socket clientSocket = serverSocket.accept();
-      console.print("Connection established!");
-      EchoServer echoServer = new EchoServer(console, socketIO, clientSocket);
 
-      new Thread(echoServer).start();
+      while (!Thread.currentThread().isInterrupted()) {
+        Socket clientSocket = serverSocket.accept();
+        console.print("Connection established!");
+        EchoServer echoServer = new EchoServer(console, socketIO, clientSocket);
+
+        new Thread(echoServer).start();
+
+      }
+    } finally {
+      serverSocket.close();
     }
   }
 }

--- a/app/src/main/java/echo/server/ServerRunner.java
+++ b/app/src/main/java/echo/server/ServerRunner.java
@@ -5,6 +5,7 @@ import echo.SocketIO;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.net.Socket;
 
 public class ServerRunner {
 
@@ -16,9 +17,13 @@ public class ServerRunner {
     ServerSocket serverSocket = new ServerSocket(49151);
     console.print("Echo Server started and waiting for clients... ");
 
-    EchoServer echoServer = new EchoServer(console, serverSocket, socketIO);
+    while (true) {
+      Socket clientSocket = serverSocket.accept();
+      console.print("Connection established!");
+      EchoServer echoServer = new EchoServer(console, socketIO, clientSocket);
 
-    echoServer.start();
+      new Thread(echoServer).start();
+    }
   }
 }
 

--- a/app/src/test/java/echo/server/EchoServerTest.java
+++ b/app/src/test/java/echo/server/EchoServerTest.java
@@ -17,23 +17,10 @@ public class EchoServerTest {
   ServerSocket mockServerSocket = mock(ServerSocket.class);
   Socket mockServerConnection = mock(Socket.class);
   Console mockConsole = mock(Console.class);
-  EchoServer echoServer = new EchoServer(mockConsole, mockServerSocket, mockSocketIO);
+  EchoServer echoServer = new EchoServer(mockConsole, mockSocketIO, mockServerConnection);
 
   public void testSetUp() throws IOException {
     when(mockServerSocket.accept()).thenReturn(mockServerConnection);
-  }
-
-  @Test
-  @DisplayName("should print a connection message when echo server starts")
-  void should_printConnectionMessage() throws IOException {
-    testSetUp();
-    when(mockSocketIO.readMessage(mockServerConnection))
-        .thenReturn("quit")
-        .thenReturn(null);
-
-    echoServer.start();
-
-    verify(mockConsole).print("Connection established!");
   }
 
   @Test
@@ -43,7 +30,7 @@ public class EchoServerTest {
     when(mockSocketIO.readMessage(mockServerConnection))
         .thenReturn(null);
 
-    echoServer.start();
+    echoServer.run();
 
     verify(mockSocketIO).readMessage(mockServerConnection);
   }
@@ -54,7 +41,7 @@ public class EchoServerTest {
     testSetUp();
     when(mockSocketIO.readMessage(mockServerConnection)).thenReturn(null);
 
-    echoServer.start();
+    echoServer.run();
 
     verify(mockSocketIO, never()).sendMessage(mockServerConnection, "quit");
   }
@@ -67,7 +54,7 @@ public class EchoServerTest {
         .thenReturn("hello")
         .thenReturn(null);
 
-    echoServer.start();
+    echoServer.run();
 
     verify(mockSocketIO).sendMessage(mockServerConnection, "hello");
   }

--- a/app/src/test/java/echo/server/EchoServerTest.java
+++ b/app/src/test/java/echo/server/EchoServerTest.java
@@ -2,14 +2,18 @@ package echo.server;
 
 import echo.Console;
 import echo.SocketIO;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class EchoServerTest {
@@ -19,6 +23,7 @@ public class EchoServerTest {
   Console mockConsole = mock(Console.class);
   EchoServer echoServer = new EchoServer(mockConsole, mockSocketIO, mockServerConnection);
 
+  @BeforeEach
   public void testSetUp() throws IOException {
     when(mockServerSocket.accept()).thenReturn(mockServerConnection);
   }
@@ -57,5 +62,79 @@ public class EchoServerTest {
     echoServer.run();
 
     verify(mockSocketIO).sendMessage(mockServerConnection, "hello");
+  }
+
+  @Test
+  @DisplayName("should connect to multiple clients when more than one client requests connection")
+  public void testMultipleClientConnections() throws IOException, InterruptedException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(outputStream));
+
+    // Create a server instance in a separate thread
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    executorService.execute(() -> {
+      try {
+        ServerRunner.main(null);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    });
+
+    Thread.sleep(1000);
+
+    // Create multiple client connections
+    int numClients = 5;
+    for (int i = 0; i < numClients; i++) {
+      Socket clientSocket = new Socket("localhost", 49151);
+      clientSocket.close();
+    }
+
+    // Wait for the server to handle all client connections
+    Thread.sleep(1000);
+
+    String expectedOutput = "Welcome to the Echo Server!\n" +
+        "Starting Server...\n" +
+        "Echo Server started and waiting for clients... \n" +
+        "Connection established!\n".repeat(numClients);
+    assertEquals(expectedOutput, outputStream.toString());
+  }
+
+  @Test
+  @DisplayName("should return messages to multiple clients when more than one client sends a message")
+  public void testMultipleClientsMessaging() throws IOException, InterruptedException {
+    ExecutorService executorService = Executors.newCachedThreadPool();
+
+    // Start the server in a separate thread
+    executorService.execute(() -> {
+      try {
+        ServerRunner.main(null);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    });
+
+    // Wait for the server to start
+    Thread.sleep(1000);
+
+    int numClients = 5;
+    for (int i = 0; i < numClients; i++) {
+      // Start each client in a separate thread
+      executorService.execute(() -> {
+        try (Socket socket = new Socket("localhost", 49151);
+             PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
+             BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+
+          String message = "quit";
+          out.println(message);
+          String response = in.readLine();
+          assertEquals(message, response);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      });
+    }
+
+    // Stop the server
+    executorService.shutdownNow();
   }
 }

--- a/app/src/test/java/echo/server/EchoServerTest.java
+++ b/app/src/test/java/echo/server/EchoServerTest.java
@@ -65,41 +65,6 @@ public class EchoServerTest {
   }
 
   @Test
-  @DisplayName("should connect to multiple clients when more than one client requests connection")
-  public void testMultipleClientConnections() throws IOException, InterruptedException {
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(outputStream));
-
-    // Create a server instance in a separate thread
-    ExecutorService executorService = Executors.newSingleThreadExecutor();
-    executorService.execute(() -> {
-      try {
-        ServerRunner.main(null);
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    });
-
-    Thread.sleep(1000);
-
-    // Create multiple client connections
-    int numClients = 5;
-    for (int i = 0; i < numClients; i++) {
-      Socket clientSocket = new Socket("localhost", 49151);
-      clientSocket.close();
-    }
-
-    // Wait for the server to handle all client connections
-    Thread.sleep(1000);
-
-    String expectedOutput = "Welcome to the Echo Server!\n" +
-        "Starting Server...\n" +
-        "Echo Server started and waiting for clients... \n" +
-        "Connection established!\n".repeat(numClients);
-    assertEquals(expectedOutput, outputStream.toString());
-  }
-
-  @Test
   @DisplayName("should return messages to multiple clients when more than one client sends a message")
   public void testMultipleClientsMessaging() throws IOException, InterruptedException {
     ExecutorService executorService = Executors.newCachedThreadPool();
@@ -124,7 +89,7 @@ public class EchoServerTest {
              PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
              BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
-          String message = "quit";
+          String message = "Hello from client!";
           out.println(message);
           String response = in.readLine();
           assertEquals(message, response);
@@ -133,6 +98,10 @@ public class EchoServerTest {
         }
       });
     }
+
+    // Wait for all clients to finish
+    executorService.shutdown();
+    Thread.sleep(5000);
 
     // Stop the server
     executorService.shutdownNow();

--- a/app/src/test/java/echo/server/EchoServerTest.java
+++ b/app/src/test/java/echo/server/EchoServerTest.java
@@ -11,7 +11,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -66,7 +65,7 @@ public class EchoServerTest {
 
   @Test
   @DisplayName("should return messages to multiple clients when more than one client sends a message")
-  public void testMultipleClientsMessaging() throws IOException, InterruptedException {
+  public void should_sendMultipleClientsMessages() throws IOException, InterruptedException {
     ExecutorService executorService = Executors.newCachedThreadPool();
 
     // Start the server in a separate thread
@@ -84,12 +83,13 @@ public class EchoServerTest {
     int numClients = 5;
     for (int i = 0; i < numClients; i++) {
       // Start each client in a separate thread
+      int finalI = i;
       executorService.execute(() -> {
         try (Socket socket = new Socket("localhost", 49151);
              PrintWriter out = new PrintWriter(socket.getOutputStream(), true);
              BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
-          String message = "Hello from client!";
+          String message = "Hello from client " + finalI;
           out.println(message);
           String response = in.readLine();
           assertEquals(message, response);
@@ -103,7 +103,6 @@ public class EchoServerTest {
     executorService.shutdown();
     Thread.sleep(5000);
 
-    // Stop the server
     executorService.shutdownNow();
   }
 }


### PR DESCRIPTION
## Changes made

1. Move accept client connection from EchoServer into `while` loop in EchoServerRunner 
2. Edit README to instruct user on how to boot things correctly

## Acceptance criteria

1. When the server receives a message from multiple clients, it should return the message back to the respective client which it came from.

## Comments
Using Kotlin in my Gradle build continues to haunt me on through this last ticket. On Friday, I dedicated some time to reconfiguring the build file and the `README` to ensure the server and clients were properly booting. Ultimately, the problem stemmed from the way newer versions of Gradle interacted with `system.in` or `system.console`, causing an infinite loop of `null` responses in my program. Luckily, I found a solution that worked for me. By executing `gradle --console plain bootClient` in the terminal, I was able to prevent Gradle from returning a `null` value, thereby avoiding the infinite null loop.

Testing multi-client messaging presented its own set of challenges, which led me to utilize ExecutorService to manage a dedicated thread for the server boot and multiple-client sockets. This allowed me to effectively test the server's capability to receive and respond to messages from multiple clients, each running in their own separate thread. However, I have some doubts regarding the suitability of this approach. Since the client functionality created for testing purposes isn't a mock, I'm uncertain if it's appropriate to create such bare-bones client functionality solely for the purpose of testing the server's multi-client capabilities. But I was unable to think of a better way to ensure that the messages were being received and responded to.

[trello ticket](https://trello.com/c/FTw3Hrr7)
